### PR TITLE
Prevent RuntimeWarning: DateTimeField received a naive datetime in django-pyas2

### DIFF
--- a/pyas2lib/as2.py
+++ b/pyas2lib/as2.py
@@ -555,7 +555,6 @@ class Message(object):
                 self.enc_alg, decrypted_content = decrypt_message(
                     encrypted_data, self.receiver.decrypt_key)
 
-                raw_content = decrypted_content
                 self.payload = parse_mime(decrypted_content)
 
                 if self.payload.get_content_type() == 'text/plain':

--- a/pyas2lib/as2.py
+++ b/pyas2lib/as2.py
@@ -305,7 +305,8 @@ class Message(object):
         return message_header.encode('utf-8')
 
     def build(self, data, filename=None, subject='AS2 Message',
-              content_type='application/edi-consent', additional_headers=None):
+              content_type='application/edi-consent', additional_headers=None,
+              disposition_notification_to='no-reply@pyas2.com'):
 
         """Function builds the AS2 message. Compresses, signs and encrypts
         the payload if applicable.
@@ -325,6 +326,10 @@ class Message(object):
 
         :param additional_headers:
             Any additional headers to be included as part of the AS2 message.
+
+        :param disposition_notification_to:
+            Email address for disposition-notification-to header entry.
+            (default "no-reply@pyas2.com")
 
         """
 
@@ -441,7 +446,7 @@ class Message(object):
                 self.message_id, self.payload.as_string()))
 
         if self.receiver.mdn_mode:
-            as2_headers['disposition-notification-to'] = 'no-reply@pyas2.com'
+            as2_headers['disposition-notification-to'] = disposition_notification_to
             if self.receiver.mdn_digest_alg:
                 as2_headers['disposition-notification-options'] = \
                     'signed-receipt-protocol=required, pkcs7-signature; ' \

--- a/pyas2lib/utils.py
+++ b/pyas2lib/utils.py
@@ -8,7 +8,7 @@ from email.generator import BytesGenerator
 from io import BytesIO
 
 from pyas2lib.exceptions import AS2Exception
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 def unquote_as2name(quoted_name):
@@ -196,8 +196,8 @@ def extract_certificate_info(cert):
 
     :param cert: the certificate as byte string in PEM or DER format
     :return: a dictionary holding certificate information:
-                valid_from (datetime)
-                valid_to (datetime)
+                valid_from (datetime) - UTC
+                valid_to (datetime) - UTC
                 subject (list of name, value tuples)
                 issuer (list of name, value tuples)
                 serial (int)
@@ -224,9 +224,11 @@ def extract_certificate_info(cert):
 
             # on successful load, extract the various fields into the dictionary
             cert_info['valid_from'] = datetime.strptime(
-                certificate.get_notBefore().decode('utf8'), "%Y%m%d%H%M%S%z")
+                certificate.get_notBefore().decode('utf8'), "%Y%m%d%H%M%SZ").\
+                replace(tzinfo=timezone.utc)
             cert_info['valid_to'] = datetime.strptime(
-                certificate.get_notAfter().decode('utf8'), "%Y%m%d%H%M%S%z")
+                certificate.get_notAfter().decode('utf8'), "%Y%m%d%H%M%SZ").\
+                replace(tzinfo=timezone.utc)
             cert_info['subject'] = [
                 tuple(item.decode('utf8') for item in sets)
                 for sets in certificate.get_subject().get_components()]

--- a/pyas2lib/utils.py
+++ b/pyas2lib/utils.py
@@ -224,9 +224,9 @@ def extract_certificate_info(cert):
 
             # on successful load, extract the various fields into the dictionary
             cert_info['valid_from'] = datetime.strptime(
-                certificate.get_notBefore().decode('utf8'), "%Y%m%d%H%M%SZ")
+                certificate.get_notBefore().decode('utf8'), "%Y%m%d%H%M%S%z")
             cert_info['valid_to'] = datetime.strptime(
-                certificate.get_notAfter().decode('utf8'), "%Y%m%d%H%M%SZ")
+                certificate.get_notAfter().decode('utf8'), "%Y%m%d%H%M%S%z")
             cert_info['subject'] = [
                 tuple(item.decode('utf8') for item in sets)
                 for sets in certificate.get_subject().get_components()]

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -331,8 +331,8 @@ class TestAdvanced(Pyas2TestCase):
          in PEM or DER format"""
 
         cert_info = {
-            'valid_from': datetime.datetime(2019, 6, 3, 11, 32, 57),
-            'valid_to': datetime.datetime(2029, 5, 31, 11, 32, 57),
+            'valid_from': datetime.datetime(2019, 6, 3, 11, 32, 57, tzinfo=datetime.timezone.utc),
+            'valid_to': datetime.datetime(2029, 5, 31, 11, 32, 57, tzinfo=datetime.timezone.utc),
             'subject': [('C', 'AU'), ('ST', 'Some-State'),
                         ('O', 'pyas2lib'), ('CN', 'test')],
             'issuer': [('C', 'AU'), ('ST', 'Some-State'),


### PR DESCRIPTION
Date parsing was lacking the timezone which throws warnings in django-pyas2. 