### PR TITLE
Fix to support multipart/related messages

### DIFF
--- a/pyas2lib/as2.py
+++ b/pyas2lib/as2.py
@@ -545,7 +545,7 @@ class Message(object):
                 # Split the message into signature and signed message
                 signature = None
                 signature_types = ['application/pkcs7-signature', 'application/x-pkcs7-signature']
-                for part in self.payload.walk():
+                for part in self.payload.get_payload():
                     if part.get_content_type() in signature_types:
                         signature = part.get_payload(decode=True)
                     else:

--- a/pyas2lib/utils.py
+++ b/pyas2lib/utils.py
@@ -53,7 +53,10 @@ class BinaryBytesGenerator(BytesGenerator):
             else:
                 self._fp.write(payload)
         else:
-            super()._handle_text(msg)
+            if isinstance(msg._payload, list):
+                super()._handle_multipart_signed(msg)
+            else:
+                super()._handle_text(msg)
 
     _writeBody = _handle_text
 


### PR DESCRIPTION
pyas2lib was failing to parse messages containing more than one EDI message - where it was expecting to find a text part it was instead finding the multipart/related part and failing.

Specifically, it was always using the last part of the message as the payload, which then resulted in a signature fail due to it missing off the other part(s). I've made it use the highest level part that isn't the signature, which will either be a text part (for single-message messages) or a multipart/related part containing the messages as children.

I also had to modify the BinaryBytesGenerator, as it did not correctly handle the multipart/related part and threw an error (due to the _payload being a list rather than text).

This seems to work (it is passing the signature check in my testing against Cleo VLTrader).