### PR TITLE
Update versions of crypto dependencies

### DIFF
--- a/pyas2lib/cms.py
+++ b/pyas2lib/cms.py
@@ -2,7 +2,7 @@ import hashlib
 import zlib
 from asn1crypto import cms, core, algos
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 from oscrypto import asymmetric, symmetric, util
 
 from pyas2lib.exceptions import *
@@ -163,7 +163,7 @@ def decrypt_message(encrypted_data, decryption_key):
             'key_encryption_algorithm']['algorithm'].native
         encrypted_key = recipient_info['encrypted_key'].native
 
-        if key_enc_alg == 'rsa':
+        if cms.KeyEncryptionAlgorithmId(key_enc_alg) == cms.KeyEncryptionAlgorithmId('rsa'):
             try:
                 key = asymmetric.rsa_pkcs1v15_decrypt(decryption_key[0], encrypted_key)
             except Exception:
@@ -175,7 +175,7 @@ def decrypt_message(encrypted_data, decryption_key):
                 'encrypted_content_info']['encrypted_content'].native
 
             try:
-                if alg['algorithm'].native == '1.2.840.113549.3.4':  # This is RC4
+                if alg['algorithm'].native == 'rc4':
                     decrypted_content = symmetric.rc4_decrypt(key, encapsulated_data)
                 elif alg.encryption_cipher == 'tripledes':
                     cipher = 'tripledes_192_cbc'
@@ -261,7 +261,7 @@ def sign_message(data_to_sign, digest_alg, sign_key,
                 'type': cms.CMSAttributeType('signing_time'),
                 'values': cms.SetOfTime([
                     cms.Time({
-                        'utc_time': core.UTCTime(datetime.now())
+                        'utc_time': core.UTCTime(datetime.utcnow().replace(tzinfo=timezone.utc))
                     })
                 ])
             }),

--- a/setup.py
+++ b/setup.py
@@ -2,20 +2,20 @@ import sys
 from setuptools import setup, find_packages
 
 install_requires = [
-    'asn1crypto==0.24.0',
-    'oscrypto==0.19.1',
-    'pyOpenSSL==17.5.0',
+    'asn1crypto==1.3.0',
+    'oscrypto==1.2.0',
+    'pyOpenSSL==19.1.0',
 ]
 
 if sys.version_info.minor == 6:
     install_requires += [
-        'dataclasses==0.6'
+        'dataclasses==0.7'
     ]
 
 tests_require = [
-    'pytest==3.4.0',
-    'pytest-cov==2.5.1',
-    'coverage==4.3.4',
+    'pytest==5.4.1',
+    'pytest-cov==2.8.1',
+    'coverage==5.0.4',
 ]
 
 setup(


### PR DESCRIPTION
The changes in asn1crypto required minor changes. Responding to the
following changes in asn1crpyto's changelog:
- cms.KeyEncryptionAlgorithmId().native now returns the value "rsaes_pkcs1v15" for OID 1.2.840.113549.1.1.1 instead of "rsa"
- Added RC4 (1.2.840.113549.3.4) to algos.EncryptionAlgorithmId()
- Require timezone-aware datetime