### PR TITLE
Determine correct signature algorithm.

### DIFF
--- a/pyas2lib/cms.py
+++ b/pyas2lib/cms.py
@@ -464,7 +464,7 @@ def verify_message(data_to_verify, signature, verify_cert):
             if digest_alg not in DIGEST_ALGORITHMS:
                 raise Exception("Unsupported Digest Algorithm")
 
-            sig_alg = signer["signature_algorithm"]["algorithm"].native
+            sig_alg = signer["signature_algorithm"].signature_algo
             sig = signer["signature"].native
             signed_data = data_to_verify
 


### PR DESCRIPTION
The "algorithm".native can contains various values such as "sha256_rsa". asn1crypto does provide a map to assign the values and this change switches from the native to the mapped value which provides: 

-- source: asn1crypto/algos.py
    def signature_algo(self):
        """
        :return:
            A unicode string of "rsassa_pkcs1v15", "rsassa_pss", "dsa" or
            "ecdsa"
        """
    ....
---