### PR TITLE
Dont replace "\n" newlines in application/octet-stream payload with "…

### DIFF
--- a/pyas2lib/tests/test_advanced.py
+++ b/pyas2lib/tests/test_advanced.py
@@ -52,9 +52,8 @@ class TestAdvanced(Pyas2TestCase):
         )
 
         # Compare the mic contents of the input and output messages
-        # self.assertEqual(original_message,
-        #                  in_message.payload.get_payload(decode=True))
         self.assertEqual(status, "processed")
+        self.assertEqual(original_message, in_message.payload.get_payload(decode=True))
         self.assertTrue(in_message.signed)
         self.assertTrue(in_message.encrypted)
         self.assertEqual(out_message.mic, in_message.mic)

--- a/pyas2lib/utils.py
+++ b/pyas2lib/utils.py
@@ -45,12 +45,10 @@ class BinaryBytesGenerator(BytesGenerator):
         Handle writing the binary messages to prevent default behaviour of
         newline replacements.
         """
-        if msg.get(
-            "Content-Transfer-Encoding"
-        ) == "binary" and msg.get_content_subtype() in [
-            "pkcs7-mime",
-            "pkcs7-signature",
-        ]:
+        if msg.get_content_type() == "application/octet-stream" or (
+            msg.get("Content-Transfer-Encoding") == "binary"
+            and msg.get_content_subtype() in ["pkcs7-mime", "pkcs7-signature",]
+        ):
             payload = msg.get_payload(decode=True)
             if payload is None:
                 return


### PR DESCRIPTION
…\r\n"

When building an AS/2 message with data of content-type "application/octet-stream",
the payload's "\n" newlines got replaced with "\r\n", leading to corrupted message payloads.

An already existing (but disabled) test that ran into the same issue, is now running green.