### PR TITLE
ValueError is triggered by asynchronous.py when micalg is in upper case

### DIFF
--- a/pyas2lib/cms.py
+++ b/pyas2lib/cms.py
@@ -261,6 +261,10 @@ def sign_message(
 
     :return: A CMS ASN.1 byte string of the signed data.
     """
+    digest_alg = digest_alg.lower()
+    if digest_alg not in DIGEST_ALGORITHMS:
+        raise Exception('Unsupported Digest Algorithm')
+
     if use_signed_attributes:
         digest_func = hashlib.new(digest_alg)
         digest_func.update(data_to_sign)

--- a/pyas2lib/cms.py
+++ b/pyas2lib/cms.py
@@ -263,7 +263,7 @@ def sign_message(
     """
     digest_alg = digest_alg.lower()
     if digest_alg not in DIGEST_ALGORITHMS:
-        raise Exception("Unsupported Digest Algorithm")
+        raise AS2Exception("Unsupported Digest Algorithm")
 
     if use_signed_attributes:
         digest_func = hashlib.new(digest_alg)

--- a/pyas2lib/cms.py
+++ b/pyas2lib/cms.py
@@ -263,7 +263,7 @@ def sign_message(
     """
     digest_alg = digest_alg.lower()
     if digest_alg not in DIGEST_ALGORITHMS:
-        raise Exception('Unsupported Digest Algorithm')
+        raise Exception("Unsupported Digest Algorithm")
 
     if use_signed_attributes:
         digest_func = hashlib.new(digest_alg)

--- a/pyas2lib/tests/test_cms.py
+++ b/pyas2lib/tests/test_cms.py
@@ -58,6 +58,15 @@ def test_signing():
             b"data", digest_alg="sha256", sign_key=sign_key, sign_alg="rsassa_pssa"
         )
 
+    # Test unsupported digest alg
+    with pytest.raises(AS2Exception):
+        cms.sign_message(
+            b"data",
+            digest_alg="sha-256",
+            sign_key=sign_key,
+            use_signed_attributes=False,
+        )
+
 
 def test_encryption():
     """Test the encryption and decryption functions."""


### PR DESCRIPTION
Issue: 
Received following header: 
signed-receipt-micalg=optional, SHA256

ValueError triggered as follows: 
hash_algorithm must be one of "md5", "sha1", "sha224", "sha256", "sha384", "sha512", "raw", not 'SHA256'

This exception is also no handled, therefore this will fail with server error in django-pyas2. 

Change: 
convert digest_alg to lower case for compatibility
check digest_alg value to be in accepted algos, else throw exception.