### PR TITLE
[Fixes #20] Fix support for binary messages.

### DIFF
--- a/pyas2lib/as2.py
+++ b/pyas2lib/as2.py
@@ -381,7 +381,11 @@ class Message(object):
         self.payload = email_message.Message()
         self.payload.set_payload(data)
         self.payload.set_type(content_type)
-        encoders.encode_7or8bit(self.payload)
+
+        if content_type.lower().startswith('application/octet-stream'):
+            self.payload['Content-Transfer-Encoding'] = 'binary'
+        else:
+            encoders.encode_7or8bit(self.payload)
 
         if filename:
             self.payload.add_header(

--- a/pyas2lib/utils.py
+++ b/pyas2lib/utils.py
@@ -45,10 +45,10 @@ class BinaryBytesGenerator(BytesGenerator):
         Handle writing the binary messages to prevent default behaviour of
         newline replacements.
         """
-        if msg.get_content_type() == "application/octet-stream" or (
-            msg.get("Content-Transfer-Encoding") == "binary"
-            and msg.get_content_subtype() in ["pkcs7-mime", "pkcs7-signature",]
-        ):
+        if (
+            msg.get_content_type() == "application/octet-stream"
+            or msg.get("Content-Transfer-Encoding") == "binary"
+                ):
             payload = msg.get_payload(decode=True)
             if payload is None:
                 return


### PR DESCRIPTION
Scope
=====

Add support for building binary AS2 messages.

Changes
=======

utils.mime_to_bytes already had  support for content type. Add automated tests and make the code more general.

From what I can see, for encrypted/compressed messages of content type `application/pkcs7-mime` the content encoding is already set to binary.

I would go further and simplify the code as follows: ignore content type and only look at content encoding.

```python
class BinaryBytesGenerator(BytesGenerator):
    """Override the bytes generator to better handle binary data."""

    def _handle_text(self, msg):
        """
        Handle writing the binary messages to prevent default behaviour of
        newline replacements.
        """
        if msg.get("Content-Transfer-Encoding") == "binary":
            payload = msg.get_payload(decode=True)
            if payload is None:
                return
            else:
                self._fp.write(payload)
        else:
            super()._handle_text(msg)

    _writeBody = _handle_text
```

Message.build was updated to explicitly set binary encoding for when content type is application/octet-stream


How to test
=========

For now, just the automated tests.
Django-AS2 needs to be updated to include the application/octet-streams in the list of allowed content types.