### PR TITLE
Upgrade oscrypto to 1.2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     "asn1crypto==1.3.0",
-    "oscrypto==1.2.0",
+    "oscrypto==1.2.1",
     "pyOpenSSL==19.1.0",
 ]
 


### PR DESCRIPTION
As a part of an upgrade to Mac OSX Big Sur, oscrypto 1.2.0 no longer works. This is fixed with version 1.2.1 https://github.com/wbond/oscrypto/pull/47

While attempting to upgrade our python to version 3.9.1 (including the new package version enforcer), `pyas2lib` was the problem child with oscrypto pinned to version 1.2.0.

This PR should be updating the oscrypto dependency to 1.2.1.

I ran tests and everything passes:
```
pytest --cov=pyas2lib --cov-config .coveragerc  --black --pylava
============================================================================================================ test session starts =============================================================================================================
platform darwin -- Python 3.9.1, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/vetcove/Development/pyas2-lib
plugins: black-0.3.12, pylava-0.3.0, cov-2.8.1
collected 78 items

setup.py ..                                                                                                                                                                                                                            [  2%]
pyas2lib/__init__.py ..                                                                                                                                                                                                                [  5%]
pyas2lib/as2.py ..                                                                                                                                                                                                                     [  7%]
pyas2lib/cms.py ..                                                                                                                                                                                                                     [ 10%]
pyas2lib/constants.py ..                                                                                                                                                                                                               [ 12%]
pyas2lib/exceptions.py ..                                                                                                                                                                                                              [ 15%]
pyas2lib/utils.py ..                                                                                                                                                                                                                   [ 17%]
pyas2lib/tests/__init__.py ..                                                                                                                                                                                                          [ 20%]
pyas2lib/tests/livetest_with_mecas2.py ..                                                                                                                                                                                              [ 23%]
pyas2lib/tests/livetest_with_oldpyas2.py ..                                                                                                                                                                                            [ 25%]
pyas2lib/tests/test_advanced.py ..................s                                                                                                                                                                                    [ 50%]
pyas2lib/tests/test_basic.py .........                                                                                                                                                                                                 [ 61%]
pyas2lib/tests/test_cms.py .....                                                                                                                                                                                                       [ 67%]
pyas2lib/tests/test_mdn.py .....                                                                                                                                                                                                       [ 74%]
pyas2lib/tests/test_utils.py ...........                                                                                                                                                                                               [ 88%]
pyas2lib/tests/test_with_mecas2.py .........                                                                                                                                                                                           [100%]

============================================================================================================== warnings summary ==============================================================================================================
setup.py
  /Users/vetcove/Development/pyas2-lib/venv/lib/python3.9/site-packages/astroid/interpreter/_import/spec.py:13: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/stable/warnings.html

---------- coverage: platform darwin, python 3.9.1-final-0 -----------
Name                     Stmts   Miss Branch BrPart  Cover
----------------------------------------------------------
pyas2lib/__init__.py         7      0      0      0   100%
pyas2lib/as2.py            424      6    160      5    98%
pyas2lib/cms.py            139      5     54      3    96%
pyas2lib/constants.py        9      0      0      0   100%
pyas2lib/exceptions.py      32      0      2      0   100%
pyas2lib/utils.py          113      5     42      4    94%
----------------------------------------------------------
TOTAL                      724     16    258     12    97%

============================================================================================ 77 passed, 1 skipped, 1 warning in 223.00s (0:03:43) ============================================================================================
```

Let me know if there's anything else needed to change here..

Thanks! 