### PR TITLE
Normalize digest algorithm to make it more compatible

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,2 +1,3 @@
 * Abhishek Ram <abhishek.ram@me.com> @abhishek-ram
 * Chad Gates @chadgates
+* Bruno Ribeiro da Silva <bruno.devpod@gmail.com> @loop0

--- a/pyas2lib/cms.py
+++ b/pyas2lib/cms.py
@@ -14,6 +14,7 @@ from pyas2lib.exceptions import (
     IntegrityError,
 )
 from pyas2lib.constants import DIGEST_ALGORITHMS
+from pyas2lib.utils import normalize_digest_alg
 
 
 def compress_message(data_to_compress):
@@ -265,7 +266,7 @@ def sign_message(
 
     :return: A CMS ASN.1 byte string of the signed data.
     """
-    digest_alg = digest_alg.lower()
+    digest_alg = normalize_digest_alg(digest_alg)
     if digest_alg not in DIGEST_ALGORITHMS:
         raise AS2Exception("Unsupported Digest Algorithm")
 
@@ -472,7 +473,7 @@ def verify_message(data_to_verify, signature, verify_cert):
 
         for signer in cms_content["content"]["signer_infos"]:
 
-            digest_alg = signer["digest_algorithm"]["algorithm"].native
+            digest_alg = normalize_digest_alg(signer["digest_algorithm"]["algorithm"].native)
             if digest_alg not in DIGEST_ALGORITHMS:
                 raise Exception("Unsupported Digest Algorithm")
 

--- a/pyas2lib/cms.py
+++ b/pyas2lib/cms.py
@@ -473,7 +473,9 @@ def verify_message(data_to_verify, signature, verify_cert):
 
         for signer in cms_content["content"]["signer_infos"]:
 
-            digest_alg = normalize_digest_alg(signer["digest_algorithm"]["algorithm"].native)
+            digest_alg = normalize_digest_alg(
+                signer["digest_algorithm"]["algorithm"].native
+            )
             if digest_alg not in DIGEST_ALGORITHMS:
                 raise Exception("Unsupported Digest Algorithm")
 

--- a/pyas2lib/tests/test_utils.py
+++ b/pyas2lib/tests/test_utils.py
@@ -160,3 +160,11 @@ def test_extract_certificate_info():
         assert utils.extract_certificate_info(fp.read()) == cert_info
 
     assert utils.extract_certificate_info(b"") == cert_empty
+
+
+def test_normalize_digest_alg_should_return_lowercase_when_string():
+    assert utils.normalize_digest_alg("SHA256") == "sha256"
+
+
+def test_normalize_digest_alg_should_return_same_when_not_string():
+    assert utils.normalize_digest_alg(None) is None

--- a/pyas2lib/utils.py
+++ b/pyas2lib/utils.py
@@ -259,3 +259,12 @@ def extract_certificate_info(cert: bytes):
 
     # return the dictionary
     return cert_info
+
+
+def normalize_digest_alg(digest_alg):
+    """Normalizes digest algorithm to lower case as some systems send it upper case"""
+
+    if not isinstance(digest_alg, str):
+        return digest_alg
+
+    return digest_alg.lower()


### PR DESCRIPTION
This is a small change to normalize the digest algorithm in places it is used as so to improve compatibility with some AS2 systems that will send it as upper case, like `SHA256`.

It would be awesome if we could get this shipped in the next version or django-pyas2.